### PR TITLE
Update ministers_usa.csv -- ".../db/events/USA/USA Domestic Policy.txt" event ID 9993717 has Strom Thurmond as possible Head of Government in 1944, but Thurmond doesn't become active until 1945.

### DIFF
--- a/db/ministers/ministers_usa.csv
+++ b/db/ministers/ministers_usa.csv
@@ -28,7 +28,7 @@ USA;Ruling Cabinet - Start;Name;Start Year;End Year;Retirement Year;Ideology;Per
 6048;Head of Government;Frank Knox;1936;1964;1999;ML;Naive Optimist;High;M6048;X
 6049;Head of Government;Charles McNary;1940;1964;1999;ML;Political Protege;High;M6037;X
 6050;Head of Government;John Bricker;1944;1964;1999;ML;Corporate Suit;High;M6050;X
-6051;Head of Government;Strom Thurmond;1945;1964;1999;SC;Old General;High;M6051;X
+6051;Head of Government;Strom Thurmond;1944;1964;1999;SC;Old General;High;M6051;X
 6052;Head of Government;George Van Horn Moseley;1936;1964;1999;PA;Old General;High;M6052;X
 6053;Head of Government;Gerald K. Smith;1936;1964;1999;PA;Happy Amateur;High;M6040;X
 6054;Head of Government;William Leahy;1938;1964;1999;PA;Old Admiral;High;Kaiserreich Leahy;X


### PR DESCRIPTION
".../db/events/USA/USA Domestic Policy.txt" event ID 9993717 has Strom Thurmond as possible Head of Government in 1944, but Thurmond doesn't become active until 1945.